### PR TITLE
Fixed Unselect Bug on Mobile

### DIFF
--- a/src/components/EvaluationTemplate.js
+++ b/src/components/EvaluationTemplate.js
@@ -27,7 +27,7 @@ function EvaluationTemplate({
               key={index}
               checked={selectedSkills.includes(skill)}
               onChange={() => toggleSkill(skill)}
-              className={`flex items-start justify-between border border-gray-300 cursor-pointer hover:bg-lightest-cyan hover:border-light-cyan rounded-lg p-3
+              className={`flex items-start justify-between border border-gray-300 cursor-pointer rounded-lg p-3
               ${
                 selectedSkills.includes(skill)
                   ? "bg-lightest-cyan"


### PR DESCRIPTION
### Pull Request Details..

ℹ️ **Story Card Link:**  
[[Link to Story Card]](https://marsmavericks.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-55)

💭 **Description:**  
Removed hover element that prevented the background of a skill to go back to being transparent once unselected (on mobile)
